### PR TITLE
Added correct weasyprint version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-weasyprint
+weasyprint==0.42.3
 pybars3
 pyyaml


### PR DESCRIPTION
Newer versions of weasyprint require python3. The one specified in requirements.txt works with python 2.7, as the project is using that.